### PR TITLE
improve OAuth documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,25 @@ A link to the "Connected accounts" user settings section will be displayed in th
 
 ### Admin settings
 
-There also is a "Connected accounts" **admin** settings section if you want to allow your Nextcloud users to use OAuth to authenticate to a specific OpenProject instance. An admin can create an OAuth app (and get a client ID and a client secret) on OpenProject side in Administration -> Authentication -> OAuth applications.
+There also is a "Connected accounts" **admin** settings section if you want to allow your Nextcloud users to use OAuth to authenticate to a specific OpenProject instance.
+
+1. As an OpenProject admin create an OAuth app 
+   1. in OpenProject go to Administration -> Authentication -> OAuth applications
+   2. use a name of your choice
+   3. as `Redirect URI` use `<nextcloud-uri>/index.php/apps/integration_openproject/oauth-redirect`
+   4. note down the Client ID and the Client Secret
+2. As an NextCloud admin configure the OpenProject integration
+   1. in NextCloud go to Settings -> Administration -> Connected accounts
+   2. provide the OpenProject address, the Client ID and the Client Secret
+3. As an NextCloud user connect to OpenProject
+   1. in NextCloud go to Settings -> Personal -> Connected accounts
+   2. provide the OpenProject address (it has to be exactly the same as provided by the administrator in step 2)
+   3. a new button `Connect to OpenProject` should be visible
+   4. click `Connect to OpenProject`
+   5. you will be redirected to OpenProject
+   6. log-in to OpenProject if you haven't already
+   7. Authorize the NextCloud App
+   8. you will be redirected back to OpenProject
 
 #### Background jobs
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -5,10 +5,10 @@
 			{{ t('integration_openproject', 'OpenProject integration') }}
 		</h2>
 		<p class="settings-hint">
-			{{ t('integration_openproject', 'If you want to allow your Nextcloud users to use OAuth to authenticate to a OpenProject instance, create an application in your OpenProject admin settings and put the application ID (AppId) and secret below.') }}
+			{{ t('integration_openproject', 'If you want to allow your Nextcloud users to use OAuth to authenticate to a OpenProject instance, create an application in your OpenProject admin settings and put the Client ID (AppId) and the Client secret below.') }}
 			<br><br>
 			<span class="icon icon-details" />
-			{{ t('integration_openproject', 'Make sure you set the "Callback URL" to') }}
+			{{ t('integration_openproject', 'Make sure you set the "Redirect URI" to') }}
 			<b> {{ redirect_uri }} </b>
 		</p>
 		<div class="grid-form">
@@ -23,24 +23,24 @@
 				@input="onInput">
 			<label for="openproject-client-id">
 				<a class="icon icon-category-auth" />
-				{{ t('integration_openproject', 'Application ID') }}
+				{{ t('integration_openproject', 'Client ID') }}
 			</label>
 			<input id="openproject-client-id"
 				v-model="state.client_id"
 				type="password"
 				:readonly="readonly"
-				:placeholder="t('integration_openproject', 'ID of your application')"
+				:placeholder="t('integration_openproject', 'Client ID of the OAuth app in OpenProject')"
 				@focus="readonly = false"
 				@input="onInput">
 			<label for="openproject-client-secret">
 				<a class="icon icon-category-auth" />
-				{{ t('integration_openproject', 'Application secret') }}
+				{{ t('integration_openproject', 'Client secret') }}
 			</label>
 			<input id="openproject-client-secret"
 				v-model="state.client_secret"
 				type="password"
 				:readonly="readonly"
-				:placeholder="t('integration_openproject', 'Client secret of your application')"
+				:placeholder="t('integration_openproject', 'Client secret of the OAuth app in OpenProject')"
 				@focus="readonly = false"
 				@input="onInput">
 		</div>


### PR DESCRIPTION
- rename labels be to consistent with OpenProject
  to reduce confusion use the same term as OpenProject 
  ![grafik](https://user-images.githubusercontent.com/2425577/147551585-e0e4773c-97fd-4f28-bd99-ff71fbfe1eae.png)
- improve OAuth documentation
  more details about how to set it up
