### PR TITLE
trim admin settings before saving them

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -104,7 +104,7 @@ class ConfigController extends Controller {
 	 */
 	public function setAdminConfig(array $values): DataResponse {
 		foreach ($values as $key => $value) {
-			$this->config->setAppValue(Application::APP_ID, $key, $value);
+			$this->config->setAppValue(Application::APP_ID, $key, trim($value));
 		}
 		return new DataResponse(1);
 	}


### PR DESCRIPTION
do the same as for the userconfig in https://github.com/eneiluj/integration_openproject/blob/master/lib/Controller/ConfigController.php#L72

mainly to ensure there are no accidental spaces at the end of the client ID and the client secret